### PR TITLE
Throw error on duplicate model

### DIFF
--- a/bothe/errors.py
+++ b/bothe/errors.py
@@ -15,33 +15,29 @@ class InputShapeError(Exception):
             self.expected_dims, self.actual_dims)
 
 
-class NotFoundError(Exception):
-    """Exception raised on missing model
-
-    Attributes:
-        name --- model name
-        tag -- model tag
-    """
+class _ModelError(Exception):
 
     def __init__(self, name: str, tag: str):
         self.name = name
         self.tag = tag
+
+
+class NotFoundError(_ModelError):
+    """Exception raised on missing model."""
 
     def __str__(self):
         return "Model {0}:{1} not found".format(self.name, self.tag)
 
 
-class NotLoadedError(Exception):
-    """Exception raised on attempt to use not loaded model.
-
-    Attributes:
-        name -- model name
-        tag -- model tag
-    """
-
-    def __init__(self, name: str, tag: str):
-        self.name = name
-        self.tag = tag
+class NotLoadedError(_ModelError):
+    """Exception raised on attempt to use not loaded model."""
 
     def __str__(self):
         return "Model {0}:{1} is not loaded".format(self.name, self.tag)
+
+
+class DuplicateError(_ModelError):
+    """Exception raised on attempt to save model with the same name and tag."""
+
+    def __str__(self):
+        return "Model {0}:{1} is a duplicate".format(self.name, self.tag)

--- a/bothe/handlers.py
+++ b/bothe/handlers.py
@@ -3,7 +3,7 @@ import io
 import json
 
 from bothe.model import Model
-from bothe.errors import InputShapeError, NotFoundError
+from bothe.errors import InputShapeError, NotFoundError, DuplicateError
 
 
 class Push:
@@ -27,8 +27,11 @@ class Push:
         if not req.can_read_body:
             raise aiohttp.web.HTTPBadRequest(text="request has no body")
 
-        model_stream = io.BytesIO(await req.read())
-        await self.models.save(name, tag, model_stream)
+        try:
+            model_stream = io.BytesIO(await req.read())
+            await self.models.save(name, tag, model_stream)
+        except DuplicateError as e:
+            raise aiohttp.web.HTTPConflict(text=str(e))
 
         return aiohttp.web.Response(status=aiohttp.web.HTTPCreated.status_code)
 

--- a/bothe/server.py
+++ b/bothe/server.py
@@ -38,7 +38,7 @@ class Server:
         loader = bothe.model.Loader(strategy=strategy, logger=logger)
 
         # A metadata storage with models details.
-        meta = bothe.storage.meta.DB(path=data_root)
+        meta = bothe.storage.meta.DB.new(path=data_root)
 
         storage = bothe.storage.local.FileSystem.new(
             path=data_root, meta=meta, loader=loader)

--- a/tests/asynctest.py
+++ b/tests/asynctest.py
@@ -31,29 +31,6 @@ class AsyncGeneratorMock(unittest.mock.MagicMock):
             raise StopAsyncIteration
 
 
-class _AsyncContextManager:
-
-    def __init__(self, async_generator):
-        self.agen = async_generator.__aiter__()
-
-    async def __aenter__(self):
-        return await self.agen.__anext__()
-
-    async def __aexit__(self, typ, value, traceback):
-        try:
-            await self.agen.__anext__()
-        except StopAsyncIteration:
-            return False
-
-
-def asynccontextmanager(func):
-    """Simple implementation of async context manager decorator."""
-    def _f(*args, **kwargs):
-        async_generator = func(*args, **kwargs)
-        return _AsyncContextManager(async_generator)
-    return _f
-
-
 def unittest_run_loop(coroutine):
     def test(*args, **kwargs):
         loop = asyncio.new_event_loop()

--- a/tests/test_server_start.py
+++ b/tests/test_server_start.py
@@ -24,3 +24,7 @@ class TestServerStart(aiohttptest.AioHTTPTestCase):
     async def test_must_create_directory(self):
         resp = await self.client.get("/status")
         self.assertEqual(resp.status, 200)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch changes the server implementation to make it return HTTP 409
Conflict on attempt to push model with the same name:tag.

closes #24 